### PR TITLE
best case lobby delete

### DIFF
--- a/src/DataModels/Services/LobbyService.cs
+++ b/src/DataModels/Services/LobbyService.cs
@@ -44,9 +44,9 @@ namespace DataModels.Services
             await this.container.CreateItemAsync(lobby, new PartitionKey(lobby.Key));
         }
 
-        public async Task DeleteItemAsync(string key)
+        public async Task DeleteItemAsync(string id, string key)
         {
-            await this.container.DeleteItemAsync<Lobby>(key, new PartitionKey(key));
+            await this.container.DeleteItemAsync<Lobby>(id, new PartitionKey(key));
         }
 
         public async Task<Lobby> GetItemAsync(string key)
@@ -101,6 +101,17 @@ namespace DataModels.Services
                 "SetCurrentArticle",
                 new PartitionKey(lobbyKey),
                 new[] { lobbyKey, userId, articleKey });
+        }
+
+        public async Task CleanClosedLobbies()
+        {
+            var query = "SELECT * FROM c where c.IsOpen = false";
+            var lobbys = await this.GetItemsAsync(query);
+
+            foreach (var lobby in lobbys)
+            {
+                await this.DeleteItemAsync(lobby.Id, lobby.Key);
+            }
         }
     }
 }

--- a/src/WebServer/BackgroundServices/CleanupService.cs
+++ b/src/WebServer/BackgroundServices/CleanupService.cs
@@ -8,10 +8,12 @@ namespace WebServer.BackgroundServices
     public class CleanupService : BackgroundService
     {
         private readonly UserService userService;
+        private readonly LobbyService lobbyService;
 
-        public CleanupService(UserService _userService)
+        public CleanupService(UserService _userService, LobbyService _lobbyService)
         {
             this.userService = _userService;
+            this.lobbyService = _lobbyService;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -21,6 +23,7 @@ namespace WebServer.BackgroundServices
                 try
                 {
                     await this.userService.CleanGuestUsers();
+                    await this.lobbyService.CleanClosedLobbies();
                 }
                 catch
                 {


### PR DESCRIPTION
add a simple best case lobby delete for when the hub has the option to set IsOpen to false.

If the server dies, then lobbies can be orphaned - this can be cleaned up later via an orphan cleaner.